### PR TITLE
Travis-CI composer cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     - php tests/prepare-composer.php
 
 install:
-    - composer install --no-interaction --prefer-source
+    - composer install --no-interaction --prefer-dist
 
 script:
     - vendor/bin/tester tests -s -c tests/php-unix.ini -p php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+## Run on container environment
+sudo: false
+
 env:
     - NETTE=2.1
     - NETTE=2.2
@@ -30,3 +33,7 @@ script:
 
 after_failure:
     - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
+
+cache:
+  directories:
+    - $HOME/.composer/cache


### PR DESCRIPTION
Explicitne pouziva Docker ke spousteni testu
Cachuje composer

[Blog post](http://blog.wyrihaximus.net/2015/07/composer-cache-on-travis/) s vice informacemi.
