### PR TITLE
Nette\SmartObject instead of Nette\Object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,27 +4,21 @@ language: php
 sudo: false
 
 env:
-    - NETTE=2.1
-    - NETTE=2.2
-    - NETTE=2.3
     - NETTE=2.4
     - NETTE=master
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - nightly
     - hhvm
 
 matrix:
-    exclude:
-        - php: 5.4
-          env: NETTE=2.4
-        - php: 5.5
-          env: NETTE=2.4
     allow_failures:
+        - php: 7.2
+        - php: nightly
         - php: hhvm
 
 before_install:

--- a/src/Tracy/Panel.php
+++ b/src/Tracy/Panel.php
@@ -20,8 +20,9 @@ if (!interface_exists('Tracy\IBarPanel') && interface_exists('Nette\Diagnostics\
  *
  * @author Hána František
  */
-class Panel extends Nette\Object implements Tracy\IBarPanel
+class Panel implements Tracy\IBarPanel
 {
+	use Nette\SmartObject;
 
 	/** @var string */
 	private $htmlPrefix;


### PR DESCRIPTION
stávající verze není kompatibilní s nette/utils 2.5

pravděpodobně rozbije kompatibilitu s nette < 2.4