### PR TITLE
Kompatibilita verze 2.x s Nette 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ php:
 matrix:
     allow_failures:
         - php: hhvm
+    include:
+        - php: 7.1
+          env:
+              - NETTE=3.0
 
 before_install:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"nette/utils": "^2.4"
 	},
 	"require-dev": {
-		"nette/tester": "~1.3",
+		"nette/tester": "^2.0",
 		"tracy/tracy": "^2.5",
 		"nette/caching": "^2.4",
 		"nette/bootstrap": "^2.4"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
 	},
 	"require-dev": {
 		"nette/tester": "~1.3",
-		"nette/nette": "^2.4"
+		"tracy/tracy": "^2.5",
+		"nette/caching": "^2.4",
+		"nette/bootstrap": "^2.4"
 	},
     "suggest": {
         "tracy/tracy": "to enable skautis panel for Tracy debug bar.",

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
 	},
 	"require": {
 		"php": ">=5.6",
-		"skautis/skautis": "~2.0@dev",
-		"nette/di": "^2.4@dev",
-		"nette/http": "^2.4@dev",
-		"nette/utils": "^2.4@dev"
+		"skautis/skautis": "^2.0",
+		"nette/di": "^2.4",
+		"nette/http": "^2.4",
+		"nette/utils": "^2.4"
 	},
 	"require-dev": {
 		"nette/tester": "~1.3",
-		"nette/nette": "^2.4@dev"
+		"nette/nette": "^2.4"
 	},
     "suggest": {
         "tracy/tracy": "to enable skautis panel for Tracy debug bar.",

--- a/src/SkautisExtension.php
+++ b/src/SkautisExtension.php
@@ -33,26 +33,26 @@ class SkautisExtension extends Nette\DI\CompilerExtension
 		$config['profiler'] = isset($config['profiler']) ? $config['profiler'] : !empty($container->parameters['debugMode']);
 
 		$container->addDefinition($this->prefix('config'))
-			->setClass(Skautis\Config::class, [$config['applicationId'], $config['testMode'], $config['cache'], $config['compression']]);
+			->setFactory(Skautis\Config::class, [$config['applicationId'], $config['testMode'], $config['cache'], $config['compression']]);
 
 		$container->addDefinition($this->prefix('webServiceFactory'))
-			->setClass(Skautis\Wsdl\WebServiceFactory::class);
+			->setFactory(Skautis\Wsdl\WebServiceFactory::class);
 
 		$manager = $container->addDefinition($this->prefix('wsdlManager'))
-			->setClass(Skautis\Wsdl\WsdlManager::class);
+			->setFactory(Skautis\Wsdl\WsdlManager::class);
 
 		$container->addDefinition($this->prefix('session'))
-			->setClass(SessionAdapter::class);
+			->setFactory(SessionAdapter::class);
 
 		$container->addDefinition($this->prefix('user'))
-			->setClass(Skautis\User::class);
+			->setFactory(Skautis\User::class);
 
 		$container->addDefinition($this->prefix('skautis'))
-			->setClass(Skautis\Skautis::class);
+			->setFactory(Skautis\Skautis::class);
 
 		if ($config['profiler'] && class_exists(Debugger::class)) {
 			$panel = $container->addDefinition($this->prefix('panel'))
-				->setClass(Skautis\Nette\Tracy\Panel::class);
+				->setFactory(Skautis\Nette\Tracy\Panel::class);
 			$manager->addSetup([$panel, 'register'], [$manager]);
 		}
 	}

--- a/tests/composer-nette-2.4.json
+++ b/tests/composer-nette-2.4.json
@@ -23,7 +23,7 @@
 		"nette/http": "2.4.*"
 	},
 	"require-dev": {
-		"nette/tester": "~1.3",
+		"nette/tester": "2.0.*",
 		"nette/caching": "2.4.*",
 		"nette/bootstrap": "2.4.*",
 		"tracy/tracy": "2.4.*"

--- a/tests/composer-nette-2.4.json
+++ b/tests/composer-nette-2.4.json
@@ -24,7 +24,7 @@
 	},
 	"require-dev": {
 		"nette/tester": "~1.3",
-		"nette/nette": "2.4.*",
+		"nette/caching": "2.4.*",
 		"nette/bootstrap": "2.4.*",
 		"tracy/tracy": "2.4.*"
 	},

--- a/tests/composer-nette-3.0.json
+++ b/tests/composer-nette-3.0.json
@@ -16,26 +16,23 @@
 		"source": "https://github.com/skaut/SkautisNette"
 	},
 	"require": {
-		"php": ">=5.6",
-		"skautis/skautis": "^2.0",
-		"nette/di": "^2.4 || ^3.0",
-		"nette/http": "^2.4 || ^3.0",
-		"nette/utils": "^2.4 || ^3.0"
+		"php": ">=7.1",
+		"skautis/skautis": "~2.0@dev",
+		"nette/utils": "3.0.*",
+		"nette/di": "3.0.*",
+		"nette/http": "3.0.*"
 	},
 	"require-dev": {
-		"nette/tester": "^2.0",
-		"tracy/tracy": "^2.5 || ^3.0",
-		"nette/caching": "^2.4 || ^3.0",
-		"nette/bootstrap": "^2.4 || ^3.0"
+		"nette/tester": "2.0.*",
+		"nette/caching": "3.0.*",
+		"nette/bootstrap": "3.0.*",
+		"tracy/tracy": "2.4.*"
 	},
-    "suggest": {
-        "tracy/tracy": "to enable skautis panel for Tracy debug bar.",
-        "nette/caching": "to use Nette caching backend in CacheDecorator."
-    },
 	"autoload": {
 		"psr-4": {
 			"Skautis\\Nette\\": "src/"
 		}
 	},
-	"minimum-stability": "stable"
+	"minimum-stability": "stable",
+	"prefer-stable": true
 }


### PR DESCRIPTION
Tak jak integrace momentálně funguje, je kompatibilní i s Nette 3.0

IMO nedává smysl čekat na skaut/skautis 3.0 (a tedy verzi 3.0 tohoto balíčku). Tohle zároveň zjednodušší uživatelům přechod na 3.0 (nebudou muset zároveň řešit BC breaky skaut/skautis) a nemusíme se skaut/skautis 3.0 spěchat.